### PR TITLE
Feat/add team label

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,83 +1,63 @@
-name: CI
-
+---
+name: ci
 on:
   push:
-    branches: [main]
-    tags:
-      - 'v*'
-  pull_request:
-  workflow_dispatch:
+    branches: [ main ]
+    tags: [ v* ]
 
 jobs:
-  build:
-    name: Build and test
-    permissions:
-      contents: write
-      packages: write
+  lint:
+    name: lint
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Login to GitHub Container Registry
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@v2
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: latest
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.19'
+      - run: go test -v ./... -covermode=atomic -coverprofile=coverage.out
+      - uses: codecov/codecov-action@v1
+        with:
+          files: coverage.out
+  docker:
+    name: docker
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - test
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ secrets.CI_USERNAME }}
-          password: ${{ secrets.CI_PAT }}
-
-      - name: Set up QEMU
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/setup-buildx-action@v2
-
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.19
-
-      - name: Cache Go modules
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: Unit tests
-        run: |
-          go test -v -covermode=atomic -coverprofile=coverage.out ./...
-
-      - name: Extract metadata from ghcr image
-        if: ${{ github.event_name != 'pull_request' }}
-        id: meta-github-image
-        uses: docker/metadata-action@v4
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/metadata-action@v3
+        id: meta
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=semver,pattern={{version}}
+            type=ref,event=branch
             type=ref,event=pr
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-
-      - name: Build docker image
-        uses: docker/build-push-action@v3
-        if: ${{ github.event_name != 'pull_request' }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      - uses: docker/build-push-action@v2
         with:
+          file: "Dockerfile"
           context: .
-          platforms: linux/amd64, linux/arm64, linux/s390x
+          platforms: linux/amd64
           push: true
-          tags: ${{ steps.meta-github-image.outputs.tags }}
-          labels: ${{ steps.meta-github-image.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Run Goreleaser
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          version: latest
-          args: release --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 AS build
+FROM golang:1.19 AS build
 
 WORKDIR /
 

--- a/exporters/exporter.go
+++ b/exporters/exporter.go
@@ -248,6 +248,13 @@ func NewExporter(name, prefix, cloud string, disabledMetrics []string, endpointT
 				return nil, err
 			}
 		}
+	case "computeWithTeam":
+		{
+			exporter, err = NewNovaTeamExporter(&exporterConfig)
+			if err != nil {
+				return nil, err
+			}
+		}
 	case "image":
 		{
 			exporter, err = NewGlanceExporter(&exporterConfig)

--- a/exporters/nova-with-team.go
+++ b/exporters/nova-with-team.go
@@ -1,0 +1,102 @@
+package exporters
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gophercloud/gophercloud/openstack/baremetal/apiversions"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/extendedserverattributes"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var defaultNovaWithTeamMetrics = []Metric{
+	{Name: "flavors", Fn: ListFlavors},
+	{Name: "flavor", Labels: []string{"id", "name", "vcpus", "ram", "disk", "is_public"}},
+	{Name: "availability_zones", Fn: ListAZs},
+	{Name: "security_groups", Fn: ListComputeSecGroups},
+	{Name: "total_vms", Fn: NovaTeamListAllServers},
+	{Name: "agent_state", Labels: []string{"id", "hostname", "service", "adminState", "zone", "disabledReason"}, Fn: ListNovaAgentState},
+	{Name: "running_vms", Labels: []string{"hostname", "availability_zone", "aggregates"}, Fn: ListHypervisors},
+	{Name: "current_workload", Labels: []string{"hostname", "availability_zone", "aggregates"}},
+	{Name: "vcpus_available", Labels: []string{"hostname", "availability_zone", "aggregates"}},
+	{Name: "vcpus_used", Labels: []string{"hostname", "availability_zone", "aggregates"}},
+	{Name: "memory_available_bytes", Labels: []string{"hostname", "availability_zone", "aggregates"}},
+	{Name: "memory_used_bytes", Labels: []string{"hostname", "availability_zone", "aggregates"}},
+	{Name: "local_storage_available_bytes", Labels: []string{"hostname", "availability_zone", "aggregates"}},
+	{Name: "local_storage_used_bytes", Labels: []string{"hostname", "availability_zone", "aggregates"}},
+	{Name: "free_disk_bytes", Labels: []string{"hostname", "availability_zone", "aggregates"}},
+	{Name: "server_status", Labels: []string{"id", "status", "name", "tenant_id", "user_id", "address_ipv4",
+		"address_ipv6", "host_id", "hypervisor_hostname", "uuid", "availability_zone", "flavor_id", "team"}},
+	{Name: "limits_vcpus_max", Labels: []string{"tenant", "tenant_id"}, Fn: ListComputeLimits, Slow: true},
+	{Name: "limits_vcpus_used", Labels: []string{"tenant", "tenant_id"}, Slow: true},
+	{Name: "limits_memory_max", Labels: []string{"tenant", "tenant_id"}, Slow: true},
+	{Name: "limits_memory_used", Labels: []string{"tenant", "tenant_id"}, Slow: true},
+	{Name: "limits_instances_used", Labels: []string{"tenant", "tenant_id"}, Slow: true},
+	{Name: "limits_instances_max", Labels: []string{"tenant", "tenant_id"}, Slow: true},
+	{Name: "server_local_gb", Labels: []string{"name", "id", "tenant_id"}, Fn: ListUsage, Slow: true},
+}
+
+func NewNovaTeamExporter(config *ExporterConfig) (*NovaExporter, error) {
+	exporter := NovaExporter{
+		BaseOpenStackExporter{
+			Name:           "nova",
+			ExporterConfig: *config,
+		},
+	}
+	for _, metric := range defaultNovaWithTeamMetrics {
+		if exporter.isDeprecatedMetric(&metric) {
+			continue
+		}
+		if !exporter.isSlowMetric(&metric) {
+			exporter.AddMetric(metric.Name, metric.Fn, metric.Labels, metric.DeprecatedVersion, nil)
+		}
+	}
+
+	envMicroversion, present := os.LookupEnv("OS_COMPUTE_API_VERSION")
+	if present {
+		exporter.Client.Microversion = envMicroversion
+	} else {
+
+		microversion, err := apiversions.Get(config.Client, "v2.1").Extract()
+		if err == nil {
+			exporter.Client.Microversion = microversion.Version
+		}
+	}
+
+	return &exporter, nil
+}
+
+// NovaTeamListAllServers is copy of ListAllServers in nova.go + team label
+func NovaTeamListAllServers(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) error {
+	type ServerWithExt struct {
+		servers.Server
+		availabilityzones.ServerAvailabilityZoneExt
+		extendedserverattributes.ServerAttributesExt
+	}
+
+	var allServers []ServerWithExt
+
+	allPagesServers, err := servers.List(exporter.Client, servers.ListOpts{AllTenants: true}).AllPages()
+	if err != nil {
+		return err
+	}
+
+	err = servers.ExtractServersInto(allPagesServers, &allServers)
+	if err != nil {
+		return err
+	}
+
+	ch <- prometheus.MustNewConstMetric(exporter.Metrics["total_vms"].Metric,
+		prometheus.GaugeValue, float64(len(allServers)))
+
+	// Server status metrics
+	for _, server := range allServers {
+		ch <- prometheus.MustNewConstMetric(exporter.Metrics["server_status"].Metric,
+			prometheus.GaugeValue, float64(mapServerStatus(server.Status)), server.ID, server.Status, server.Name, server.TenantID,
+			server.UserID, server.AccessIPv4, server.AccessIPv6, server.HostID, server.HypervisorHostname, server.ID, server.AvailabilityZone, fmt.Sprintf("%v", server.Flavor["id"]), getTeam(server.TenantID))
+	}
+
+	return nil
+}

--- a/exporters/team.go
+++ b/exporters/team.go
@@ -1,0 +1,121 @@
+package exporters
+
+import (
+	"crypto/tls"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
+	"github.com/gophercloud/utils/openstack/clientconfig"
+	"github.com/prometheus/common/log"
+)
+
+// TeamSuffix is suffix of labels on tenenat e.g: test-team
+const TeamSuffix string = "-team"
+
+// tenant_id:teamName
+var projectIDTeamMap = make(map[string]string)
+var projectIDTeamMapMutex sync.RWMutex
+
+// get team name from projectIDTeamMa
+func getTeam(tenantId string) string {
+	projectIDTeamMapMutex.RLock()
+	teamName := projectIDTeamMap[tenantId]
+	projectIDTeamMapMutex.RUnlock()
+	return teamName
+}
+
+// UpdateProjectIDTeamMap job is get and set tenant_id:teamName to projectIDTeamMap
+func UpdateProjectIDTeamMap() {
+	extractTeamFromTags := func(tags []string) (tag string) {
+		for _, t := range tags {
+			if strings.HasSuffix(t, TeamSuffix) {
+				return t
+			}
+		}
+		return ""
+	}
+
+	allProjects, err := listAllProjects()
+	if err == nil {
+		ProjectsWithTeamTag := getProjectsWithTeamTag(allProjects)
+		projectIDTeamMapMutex.Lock()
+		go func() {
+			for _, p := range ProjectsWithTeamTag {
+				projectIDTeamMap[p.ID] = extractTeamFromTags(p.Tags)
+
+			}
+		}()
+		projectIDTeamMapMutex.Unlock()
+	}
+}
+
+// getProjectsWithTeamTag get all projects and return list of project that has -team label
+func getProjectsWithTeamTag(projs []projects.Project) []projects.Project {
+	projectsWtihTeamTag := make([]projects.Project, 0)
+	isTagsContainTeam := func(tags []string) bool {
+		for _, tag := range tags {
+			if strings.HasSuffix(tag, TeamSuffix) {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, p := range projs {
+		if isTagsContainTeam(p.Tags) {
+			projectsWtihTeamTag = append(projectsWtihTeamTag, p)
+		}
+	}
+	return projectsWtihTeamTag
+}
+
+// listAllProject return all projects that get from openstack.
+func listAllProjects() ([]projects.Project, error) {
+
+	var allProjects []projects.Project
+
+	allPagesProject, err := projects.List(TeamServiceClient, projects.ListOpts{}).AllPages()
+	if err != nil {
+		log.Errorf("could not get projects: %s", err)
+		return nil, err
+	}
+
+	allProjects, err = projects.ExtractProjects(allPagesProject)
+	if err != nil {
+		log.Errorf("projects Extrcat failed: %s", err)
+		return nil, err
+	}
+	return allProjects, nil
+
+}
+
+var TeamServiceClient *gophercloud.ServiceClient
+
+// NewTeamServiceClient creae and return a keystone client
+func NewTeamServiceClient(cloud string, endpointType string) (*gophercloud.ServiceClient, error) {
+	clientName := "identity"
+	var err error
+	var transport *http.Transport
+
+	opts := clientconfig.ClientOpts{Cloud: cloud}
+
+	config, err := clientconfig.GetCloudFromYAML(&opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if !*config.Verify {
+		log.Infoln("SSL verification disabled on transport")
+		tlsConfig := &tls.Config{InsecureSkipVerify: true}
+		transport = &http.Transport{TLSClientConfig: tlsConfig}
+	}
+
+	client, err := NewServiceClient(clientName, &opts, transport, endpointType)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}

--- a/exporters/utils.go
+++ b/exporters/utils.go
@@ -121,6 +121,8 @@ func NewServiceClient(service string, opts *clientconfig.ClientOpts, transport *
 		return openstack.NewClusteringV1(pClient, eo)
 	case "compute":
 		return openstack.NewComputeV2(pClient, eo)
+	case "computeWithTeam":
+		return openstack.NewComputeV2(pClient, eo)
 	case "container":
 		return openstack.NewContainerV1(pClient, eo)
 	case "container-infra":

--- a/main.go
+++ b/main.go
@@ -193,18 +193,19 @@ func metricHandler(services map[string]*bool) http.HandlerFunc {
 }
 
 func prepareTeam(services map[string]*bool, cloud *string, endpointType *string) map[string]*bool {
-	var err error
-	if teamexporterIsDisable := *services["computeWithTeam"]; !teamexporterIsDisable {
+	if !*services["computeWithTeam"] {
 		//Disable Original Compute exporter
 		computeServiceState := *services["compute"]
 		*services["compute"] = true
-		exporters.TeamServiceClient, err = exporters.NewTeamServiceClient(*cloud, *endpointType)
+
+		client, err := exporters.NewTeamServiceClient(*cloud, *endpointType)
 		if err != nil {
 			// if registering computeWithTeam failed, then enable original compute exporter
 			log.Errorf("enabling exporter for service %s failed: %s", "team-identity", err)
 			*services["compute"] = computeServiceState
 			*services["computeWithTeam"] = true
 		} else {
+			exporters.TeamServiceClient = client
 			go exporters.UpdateProjectIDTeamMap()
 		}
 	}


### PR DESCRIPTION
This merge request includes the following changes:

This commit adds the "team" label to the "openstack_nova_server_status" metric.
During initialization, it retrieves the tenant label, which includes the suffix "-team," and stores it in a map.
The new exporter, specifically in the file "nova-with-team.go," utilizes this label to associate each server with its corresponding team.